### PR TITLE
Allow data that can be cast to the required type unless the required type is a string

### DIFF
--- a/datatype/validation.py
+++ b/datatype/validation.py
@@ -44,10 +44,19 @@ def failures(datatype, value, path=''):
                 fails.append(_failure(path,
                     'unexpected null for non-nullable type'))
         elif val_type not in req_type:
-            fails.append(_failure(path,
-                'expected %s, got %s',
-                req_type[0].__name__, val_type.__name__
-            ))
+            if datatype != 'str':
+                for t in req_type:
+                    try:
+                        value = t(value)
+                    except TypeError:
+                        pass
+                    except ValueError:
+                        pass
+            if type(value) not in req_type:
+                fails.append(_failure(path,
+                    'expected %s, got %s',
+                    req_type[0].__name__, val_type.__name__
+                ))
 
     # Object Validation
     elif dt_type == dict:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -7,7 +7,11 @@ from datatype.validation import (BadDatatypeDefinitionError,
 
 
 def test_is_valid_primitive():
-    assert is_valid("int", 5)
+    assert is_valid('int', 5)
+    assert is_valid('int', '5')
+    assert is_valid('float', '1.0')
+    assert is_valid('bool', '0')
+    assert is_valid('bool', 1)
 
 
 def test_is_valid_object():
@@ -16,7 +20,7 @@ def test_is_valid_object():
 
 
 def test_failures_primitive():
-    assert failures('int', '5') == ['expected int, got str']
+    assert failures('int', 'foo') == ['expected int, got str']
 
 
 def test_failures_unicode_is_str():


### PR DESCRIPTION
Hi Adam,

We ran into some issues on Monday where Phoenix was passing everything to the API as a string.  I figured, rather than manually cast each and every value to its proper type, maybe we could loosen up the validation a bit more.  What do you think?

Chuck
